### PR TITLE
feat: stringify request body

### DIFF
--- a/ask.js
+++ b/ask.js
@@ -1,11 +1,21 @@
 const fetch = require('node-fetch');
 
+const defaults = {
+  responseType: 'json',
+  method: 'get',
+};
+
+const isObject = v => typeof v === 'object' && !Array.isArray(v) && v !== null;
+
+const encodeBody = config => {
+  if (!isObject(config.body)) return config;
+
+  // if body is an object, stringify it
+  return { ...config, body: JSON.stringify(config.body) };
+};
+
 module.exports = async function ask(url, config) {
-  const defaults = {
-    responseType: 'json',
-    method: 'get',
-  };
-  const { responseType, ...init } = { ...defaults, ...config };
+  const { responseType, ...init } = { ...defaults, ...encodeBody(config) };
   const response = await fetch(url, init);
 
   if (!response.ok) {

--- a/ask.spec.js
+++ b/ask.spec.js
@@ -89,4 +89,45 @@ describe('fetch request', () => {
       expect(err.statusCode).toEqual(500);
     }
   });
+
+  describe('object body', () => {
+    beforeEach(() => {
+      fetch.mockResolvedValue({ ok: true, json: jest.fn() });
+    });
+
+    test('stringifies the object body', async () => {
+      const body = { stringify: 'me' };
+      await ask('test/fetch/url', {
+        method: 'get',
+        responseType: 'json',
+        body,
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        'test/fetch/url',
+        expect.objectContaining({
+          body: JSON.stringify(body),
+        })
+      );
+    });
+
+    test('does nothing if body is a string', async () => {
+      await ask('test/fetch/url', {
+        method: 'get',
+        responseType: 'json',
+        body: '{}',
+        headers: {
+          'X-Sent-From': 'jest',
+        },
+      });
+
+      expect(fetch).toHaveBeenCalledWith('test/fetch/url', {
+        body: '{}',
+        headers: {
+          'X-Sent-From': 'jest',
+        },
+        method: 'get',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #3 

# Objective

When making a request with a body property, and given an object for the value, stringify the object so that the consumer does not have to.

# Changes

- Check the type of the body, if it's an object, run it through `JSON.stringify`
- Add tests for this behavior