### PR TITLE
feat: set content type header when stringifying body

### DIFF
--- a/ask.js
+++ b/ask.js
@@ -11,7 +11,25 @@ const encodeBody = config => {
   if (!isObject(config.body)) return config;
 
   // if body is an object, stringify it
-  return { ...config, body: JSON.stringify(config.body) };
+  const newConfig = { ...config, body: JSON.stringify(config.body) };
+
+  // set content-type header if not already set
+  if (!config.headers) {
+    return {
+      ...newConfig,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+  }
+
+  const keys = Object.keys(config.headers);
+  const contentType = keys.find(key => key.toLowerCase() === 'content-type');
+
+  // content-type header exists, don't modify it
+  if (contentType) return newConfig;
+
+  return { ...newConfig, headers: { ...config.headers, 'Content-Type': 'application/json' } };
 };
 
 module.exports = async function ask(url, config) {

--- a/ask.spec.js
+++ b/ask.spec.js
@@ -129,5 +129,51 @@ describe('fetch request', () => {
         method: 'get',
       });
     });
+
+    test('sets the content-type header', async () => {
+      const body = { hello: 'world' };
+      await ask('test/fetch/url', {
+        method: 'get',
+        responseType: 'json',
+        body,
+      });
+
+      expect(fetch).toHaveBeenCalledWith('test/fetch/url', expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' }
+      }));
+    });
+
+    test('does not change the content-type header if set', async () => {
+      await ask('test/fetch/url', {
+        method: 'get',
+        responseType: 'json',
+        body: {},
+        headers: {
+          'Content-Type': 'text/plain'
+        }
+      });
+
+      expect(fetch).toHaveBeenCalledWith('test/fetch/url', expect.objectContaining({
+        headers: { 'Content-Type': 'text/plain' }
+      }));
+    });
+
+    test('does not affect other headers', async () => {
+      await ask('test/fetch/url', {
+        method: 'get',
+        responseType: 'json',
+        body: {},
+        headers: {
+          'X-Sent-From': 'jest'
+        }
+      });
+
+      expect(fetch).toHaveBeenCalledWith('test/fetch/url', expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Sent-From': 'jest',
+        },
+      }));
+    });
   });
 });


### PR DESCRIPTION
~~Depends on #4; this contains the two commits there because it builds off that work. They can be removed and this PR reviewed once it's merged.~~ Merged, this PR has been updated.

# Objective

When the request body contains an object, we can be pretty confident that the `Content-Type` should be set to `application/json`. This PR does just that, preserving any other value that may have been set.

# Changes

- When stringifying an object body, and the `Content-Type` header is not set, add it and set it to `application/json`

I consider this a breaking change, because setting the headers automatically is new and potentially unexpected behavior.