### PR TITLE
fix: throwing without config

### DIFF
--- a/ask.js
+++ b/ask.js
@@ -14,7 +14,7 @@ const encodeBody = config => {
   return { ...config, body: JSON.stringify(config.body) };
 };
 
-module.exports = async function ask(url, config) {
+module.exports = async function ask(url, config = {}) {
   const { responseType, ...init } = { ...defaults, ...encodeBody(config) };
   const response = await fetch(url, init);
 

--- a/ask.spec.js
+++ b/ask.spec.js
@@ -64,6 +64,17 @@ describe('fetch request', () => {
     expect(response).toEqual({ ok: true, body: ['url 1', 'url 2'] });
   });
 
+  test('works without a config object', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn(() => ['url 1', 'url 2']), // treats response as json by default
+    });
+
+    const response = await ask('test/fetch/url');
+
+    expect(response).toEqual(['url 1', 'url 2']);
+  });
+
   test('response not ok throws error', async () => {
     fetch.mockResolvedValue({
       ok: false,


### PR DESCRIPTION
# Objective

The module was throwing when being used without a config object. This was caused by the config object being undefined by default, and throwing when attempting to check the body value on it.

## Changes

- Make the config object an empty object by default
- Add tests for requests without a config object 